### PR TITLE
Add move-to-next/previous-diff commands

### DIFF
--- a/keymaps/git-diff.cson
+++ b/keymaps/git-diff.cson
@@ -1,0 +1,3 @@
+'.editor':
+  'ctrl-g down': 'git-diff:move-to-next-diff'
+  'ctrl-g up': 'git-diff:move-to-previous-diff'

--- a/lib/git-diff-view.coffee
+++ b/lib/git-diff-view.coffee
@@ -25,6 +25,37 @@ class GitDiffView
       @unsubscribe()
       @unsubscribeFromBuffer()
 
+    @editor.command 'git-diff:move-to-next-diff', => @moveToNextDiff()
+    @editor.command 'git-diff:move-to-previous-diff', => @moveToPreviousDiff()
+
+  moveToNextDiff: ->
+    cursorLineNumber = @editor.getCursorBufferPosition().row + 1
+    nextDiffLineNumber = null
+    hunks = @diffs[@editor.getPath()] ? []
+    for {newStart} in hunks when newStart > cursorLineNumber
+      if nextDiffLineNumber?
+        nextDiffLineNumber = Math.min(newStart - 1, nextDiffLineNumber)
+      else
+        nextDiffLineNumber = newStart - 1
+
+    @moveToLineNumber(nextDiffLineNumber)
+
+  moveToPreviousDiff: ->
+    cursorLineNumber = @editor.getCursorBufferPosition().row + 1
+    previousDiffLineNumber = -1
+    hunks = @diffs[@editor.getPath()] ? []
+    for {newStart} in hunks when newStart < cursorLineNumber
+      previousDiffLineNumber = Math.max(newStart - 1, previousDiffLineNumber)
+
+    @moveToLineNumber(previousDiffLineNumber)
+
+  moveToLineNumber: (lineNumber=-1) ->
+    if lineNumber >= 0
+      @editor.setCursorBufferPosition([lineNumber, 0])
+      @editor.moveCursorToFirstCharacterOfLine()
+    else
+      atom.beep()
+
   unsubscribeFromBuffer: ->
     if @buffer?
       @removeDiffs()

--- a/spec/git-diff-spec.coffee
+++ b/spec/git-diff-spec.coffee
@@ -68,3 +68,25 @@ describe "GitDiff package", ->
       runs ->
         expect(editor.find('.git-line-modified').length).toBe 1
         expect(editor.find('.git-line-modified')).toHaveClass('line-number-0')
+
+  describe "move-to-next-diff/move-to-previous-diff events", ->
+    it "moves the cursor to first character of the next/previous diff line", ->
+      editor.insertText('a')
+      editor.setCursorBufferPosition([5])
+      editor.deleteLine()
+      advanceClock(editor.getBuffer().stoppedChangingDelay)
+
+      editor.setCursorBufferPosition([0])
+      editor.trigger 'git-diff:move-to-next-diff'
+      expect(editor.getCursorBufferPosition()).toEqual [4, 4]
+
+      spyOn(atom, 'beep')
+      editor.trigger 'git-diff:move-to-next-diff'
+      expect(atom.beep.callCount).toBe 1
+
+      editor.trigger 'git-diff:move-to-previous-diff'
+      expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+
+      atom.beep.reset()
+      editor.trigger 'git-diff:move-to-previous-diff'
+      expect(atom.beep.callCount).toBe 1


### PR DESCRIPTION
`ctrl-g down` to move to the line of the next diff in the editor, `ctrl-g up` to move to the previous diff.
