### PR TITLE
add option for diff icons in gutter

### DIFF
--- a/lib/git-diff-view.coffee
+++ b/lib/git-diff-view.coffee
@@ -30,6 +30,12 @@ class GitDiffView
     @subscribeToCommand @editorView, 'git-diff:move-to-previous-diff', =>
       @moveToPreviousDiff()
 
+    @subscribe atom.config.observe 'git-diff.showIconsInEditorGutter', =>
+      if atom.config.get 'git-diff.showIconsInEditorGutter'
+        @gutter.addClass('git-diff-icon')
+      else
+        @gutter.removeClass('git-diff-icon')
+
   moveToNextDiff: ->
     cursorLineNumber = @editor.getCursorBufferPosition().row + 1
     nextDiffLineNumber = null

--- a/lib/git-diff.coffee
+++ b/lib/git-diff.coffee
@@ -1,6 +1,9 @@
 GitDiffView = require './git-diff-view'
 
 module.exports =
+  configDefaults:
+    showIconsInEditorGutter: false
+
   activate: ->
     atom.workspaceView.eachEditorView (editor) ->
       if atom.project.getRepo()? and editor.attached and editor.getPane()?

--- a/stylesheets/git-diff.less
+++ b/stylesheets/git-diff.less
@@ -1,4 +1,6 @@
 @import "syntax-variables";
+@import "octicon-utf-codes";
+@import "octicon-mixins";
 
 .editor {
   .gutter .line-number {
@@ -15,6 +17,34 @@
     &.git-line-removed {
       border-left: 2px solid @syntax-color-removed;
       padding-left: ~"calc(0.5em - 2px)";
+    }
+  }
+  .gutter.git-diff-icon .line-number {
+    width: 100%;
+    border-left: none;
+    padding-left: 0.4em;
+
+    &:before {
+     .octicon-font();
+      display: inline-block;
+      width: 14px;
+      content: " ";
+      padding-right: 6px;
+    }
+
+    &.git-line-modified:before {
+      content: @primitive-dot;
+      color: @syntax-color-modified;
+    }
+
+    &.git-line-added:before {
+      content: @plus;
+      color: @syntax-color-added;
+    }
+
+    &.git-line-removed:before {
+      content: @dash;
+      color: @syntax-color-removed;
     }
   }
 }


### PR DESCRIPTION
Adds an option to replace the border with icons in the right side of the gutter.
I didn't use octicons (edit: diff icons) as the diff icon's borders add a lot of visual clutter to the gutter and makes it hard to see the icon content.

I used consistent colours and shapes.
![git-diff](https://f.cloud.github.com/assets/154176/2407516/bd2489ae-aa8d-11e3-8d80-8dc2cfcbf87c.png)

Related: #7
