### PR TITLE
Improve line removed markers / removed markers are confusing

### DIFF
--- a/stylesheets/git-diff.less
+++ b/stylesheets/git-diff.less
@@ -15,12 +15,19 @@
     }
 
     &.git-line-removed:before {
-      content: " ";
+      @size: 4px;
+
       position: absolute;
       left: 0;
-      bottom: -1px;
-      width: 8px;
-      border-bottom: 2px solid @syntax-color-removed;
+      bottom: -@size;
+      height: 0;
+      width: 0;
+      content: " ";
+      border: solid transparent;
+      border-left-color: @syntax-color-removed;
+      border-width: @size;
+      margin-top: -@size;
+      pointer-events: none;
     }
   }
   .gutter.git-diff-icon .line-number {
@@ -53,13 +60,11 @@
     }
 
     &.git-line-removed:before {
-      content: " ";
-      position: absolute;
-      left: 7px;
-      bottom: -1px;
-      top: auto;
-      width: 8px;
-      border-bottom: 3px solid @syntax-color-removed;
+      border: none; // reset triangle
+      content: @dash;
+      color: @syntax-color-removed;
+      position: relative;
+      top: .6em;
     }
   }
 }


### PR DESCRIPTION
Based on @felixkiss' suggestion from #20. This is tweaked a bit to make it look
reasonable when the gutter is wide. I also use the same technique when icons
are enabled. In the following images, line 14 has been removed.

Without icons:
![image](https://cloud.githubusercontent.com/assets/4427/3568036/822fc77c-0b28-11e4-8d8f-a8e495a66966.png)

With icons:
![image](https://cloud.githubusercontent.com/assets/4427/3568056/e565bebe-0b28-11e4-9df0-76e6dc49a72b.png)
