### PR TITLE
Fix mark visibility into the gutter

### DIFF
--- a/stylesheets/git-diff.less
+++ b/stylesheets/git-diff.less
@@ -41,16 +41,19 @@
     &.git-line-modified:before {
       content: @primitive-dot;
       color: @syntax-color-modified;
+      visibility: visible;
     }
 
     &.git-line-added:before {
       content: @plus;
       color: @syntax-color-added;
+      visibility: visible;
     }
 
     &.git-line-removed:before {
       content: @dash;
       color: @syntax-color-removed;
+      visibility: visible;
     }
   }
 }


### PR DESCRIPTION
The mark in the gutter is not visible with the last atom version, this add 'visibility: visible;' to the marks.
