### PR TITLE
enable highlighting of diff blocks in gutter background #78

### DIFF
--- a/lib/git-diff-view.coffee
+++ b/lib/git-diff-view.coffee
@@ -26,16 +26,22 @@ class GitDiffView
     @subscriptions.add atom.commands.add editorView, 'git-diff:move-to-previous-diff', =>
       @moveToPreviousDiff()
 
+    @subscriptions.add atom.config.onDidChange 'git-diff.highlightBackgroundInEditorGutter', =>
+      @updateLineNumberBackground()
+
     @subscriptions.add atom.config.onDidChange 'git-diff.showIconsInEditorGutter', =>
       @updateIconDecoration()
 
     @subscriptions.add atom.config.onDidChange 'editor.showLineNumbers', =>
+      @updateLineNumberBackground()
       @updateIconDecoration()
 
     editorElement = atom.views.getView(@editor)
     @subscriptions.add editorElement.onDidAttach =>
+      @updateLineNumberBackground()
       @updateIconDecoration()
 
+    @updateLineNumberBackground()
     @updateIconDecoration()
     @scheduleUpdate()
 
@@ -55,6 +61,13 @@ class GitDiffView
     nextDiffLineNumber = firstDiffLineNumber unless nextDiffLineNumber?
 
     @moveToLineNumber(nextDiffLineNumber)
+
+  updateLineNumberBackground: ->
+    gutter = atom.views.getView(@editor).rootElement?.querySelector('.gutter')
+    if atom.config.get('editor.showLineNumbers') and atom.config.get('git-diff.highlightBackgroundInEditorGutter')
+      gutter?.classList.add('git-diff-background')
+    else
+      gutter?.classList.remove('git-diff-background')
 
   updateIconDecoration: ->
     gutter = atom.views.getView(@editor).rootElement?.querySelector('.gutter')

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -9,6 +9,10 @@ toggleDiffList = ->
 
 module.exports =
   config:
+    highlightBackgroundInEditorGutter:
+      type: 'boolean'
+      default: false
+      description: 'Highlight the background color in the editor\'s gutter.'
     showIconsInEditorGutter:
       type: 'boolean'
       default: false

--- a/spec/git-diff-spec.coffee
+++ b/spec/git-diff-spec.coffee
@@ -121,6 +121,24 @@ describe "GitDiff package", ->
       atom.commands.dispatch(editorView, 'git-diff:move-to-previous-diff')
       expect(editor.getCursorBufferPosition()).toEqual [4, 4]
 
+  describe "when the highlightBackgroundInEditorGutter config option is true", ->
+    beforeEach ->
+      atom.config.set 'git-diff.highlightBackgroundInEditorGutter', true
+
+    it "the gutter has a git-diff-background class", ->
+      expect(editorView.rootElement.querySelector('.gutter')).toHaveClass 'git-diff-background'
+
+    it "keeps the git-diff-background class when editor.showLineNumbers is toggled", ->
+      atom.config.set 'editor.showLineNumbers', false
+      expect(editorView.rootElement.querySelector('.gutter')).not.toHaveClass 'git-diff-background'
+
+      atom.config.set 'editor.showLineNumbers', true
+      expect(editorView.rootElement.querySelector('.gutter')).toHaveClass 'git-diff-background'
+
+    it "removes the git-diff-background class when the highlightBackgroundInEditorGutter config option set to false", ->
+      atom.config.set 'git-diff.highlightBackgroundInEditorGutter', false
+      expect(editorView.rootElement.querySelector('.gutter')).not.toHaveClass 'git-diff-background'
+
   describe "when the showIconsInEditorGutter config option is true", ->
     beforeEach ->
       atom.config.set 'git-diff.showIconsInEditorGutter', true

--- a/styles/git-diff.less
+++ b/styles/git-diff.less
@@ -31,6 +31,19 @@ atom-text-editor::shadow {
       pointer-events: none;
     }
   }
+  .gutter.git-diff-background .line-number {
+    &.git-line-modified {
+      background-color: darken( @syntax-color-modified, 40% );
+    }
+
+    &.git-line-added {
+      background-color: darken( @syntax-color-added, 50% );
+    }
+
+    &.git-line-removed {
+      // background-color: darken( @syntax-color-removed, 20% );
+    }
+  }
   .gutter.git-diff-icon .line-number {
     width: 100%;
     border-left: none;


### PR DESCRIPTION
After I opened #78, I got inspired and worked up this PR.  I'm not very familiar with CS and Less, but it appears to work.  This includes a new config setting for highlighting the background color in the gutter, as well as tests.  I followed the code that adds the +/./- icons pretty closely, as you'll see.

Please review and let me know if I got anything wrong. Thank you!