### PR TITLE
Stop using async git repo (for now)

### DIFF
--- a/lib/diff-list-view.coffee
+++ b/lib/diff-list-view.coffee
@@ -29,18 +29,11 @@ class DiffListView extends SelectListView
         @div "-#{oldStart},#{oldLines} +#{newStart},#{newLines}", class: 'secondary-line'
 
   populate: ->
-    path = @editor.getPath()
-    repo = repositoryForPath(path)
-    repo?.getLineDiffs(path, @editor.getText())
-      .then (diffs) =>
-        diffs = diffs or []
-        for diff in diffs
-          bufferRow = if diff.newStart > 0 then diff.newStart - 1 else diff.newStart
-          diff.lineText = @editor.lineTextForBufferRow(bufferRow)?.trim() ? ''
-        @setItems(diffs)
-      .catch (e) ->
-        console.error('Error getting line diffs:')
-        console.error(e)
+    diffs = repositoryForPath(@editor.getPath())?.getLineDiffs(@editor.getPath(), @editor.getText()) ? []
+    for diff in diffs
+      bufferRow = if diff.newStart > 0 then diff.newStart - 1 else diff.newStart
+      diff.lineText = @editor.lineTextForBufferRow(bufferRow)?.trim() ? ''
+    @setItems(diffs)
 
   toggle: ->
     if @panel.isVisible()

--- a/lib/git-diff-view.coffee
+++ b/lib/git-diff-view.coffee
@@ -99,15 +99,10 @@ class GitDiffView
   updateDiffs: =>
     return if @editor.isDestroyed()
 
+    @removeDecorations()
     if path = @editor?.getPath()
-      @repository?.getLineDiffs(path, @editor.getText())
-        .then (diffs) =>
-          @removeDecorations()
-          @diffs = diffs
-          @addDecorations(@diffs)
-        .catch (e) ->
-          console.error('Error getting line diffs for ' + path + ':')
-          console.error(e)
+      if @diffs = @repository?.getLineDiffs(path, @editor.getText())
+        @addDecorations(@diffs)
 
   addDecorations: (diffs) ->
     for {oldStart, newStart, oldLines, newLines} in diffs

--- a/lib/git-diff-view.coffee
+++ b/lib/git-diff-view.coffee
@@ -101,11 +101,6 @@ class GitDiffView
 
     if path = @editor?.getPath()
       @repository?.getLineDiffs(path, @editor.getText())
-        .catch (e) ->
-          if e.message.match(/does not exist in the given tree/)
-            []
-          else
-            Promise.reject(e)
         .then (diffs) =>
           @removeDecorations()
           @diffs = diffs

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -5,5 +5,5 @@ module.exports =
   repositoryForPath: (goalPath) ->
     for directory, i in atom.project.getDirectories()
       if goalPath is directory.getPath() or directory.contains(goalPath)
-        return atom.project.getRepositories()[i]?.async
+        return atom.project.getRepositories()[i]
     null

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-diff",
-  "version": "1.0.1",
+  "version": "1.1.0-sync-git",
   "main": "./lib/main",
   "description": "Marks lines in the editor gutter that have been added, edited, or deleted since the last commit.",
   "repository": "https://github.com/atom/git-diff",

--- a/spec/diff-list-view-spec.coffee
+++ b/spec/diff-list-view-spec.coffee
@@ -29,21 +29,12 @@ describe "git-diff:toggle-diff-list", ->
   afterEach ->
     diffListView.cancel()
 
-  expectedLine = "while(items.length > 0) {a-5,1 +5,1"
-
   it "shows a list of all diff hunks", ->
     diffListView = $(atom.views.getView(atom.workspace)).find('.diff-list-view').view()
-
-    waitsFor ->
-      diffListView.list.children().text() is expectedLine
-    runs ->
-      expect(diffListView.list.children().text()).toBe expectedLine
+    expect(diffListView.list.children().text()).toBe "while(items.length > 0) {a-5,1 +5,1"
 
   it "moves the cursor to the selected hunk", ->
     editor.setCursorBufferPosition([0, 0])
     diffListView = $(atom.views.getView(atom.workspace)).find('.diff-list-view').view()
-    waitsFor ->
-      diffListView.list.children().text() is expectedLine
-    runs ->
-      atom.commands.dispatch(diffListView.element, 'core:confirm')
-      expect(editor.getCursorBufferPosition()).toEqual [4, 4]
+    atom.commands.dispatch(diffListView.element, 'core:confirm')
+    expect(editor.getCursorBufferPosition()).toEqual [4, 4]

--- a/spec/git-diff-spec.coffee
+++ b/spec/git-diff-spec.coffee
@@ -32,11 +32,8 @@ describe "GitDiff package", ->
       expect(editorView.rootElement.querySelectorAll('.git-line-modified').length).toBe 0
       editor.insertText('a')
       advanceClock(editor.getBuffer().stoppedChangingDelay)
-      waitsFor ->
-        editorView.rootElement.querySelectorAll('.git-line-modified').length is 1
-      runs ->
-        expect(editorView.rootElement.querySelectorAll('.git-line-modified').length).toBe 1
-        expect(editorView.rootElement.querySelector('.git-line-modified')).toHaveData("buffer-row", 0)
+      expect(editorView.rootElement.querySelectorAll('.git-line-modified').length).toBe 1
+      expect(editorView.rootElement.querySelector('.git-line-modified')).toHaveData("buffer-row", 0)
 
   describe "when the editor has added lines", ->
     it "highlights the added lines", ->
@@ -45,11 +42,8 @@ describe "GitDiff package", ->
       editor.insertNewline()
       editor.insertText('a')
       advanceClock(editor.getBuffer().stoppedChangingDelay)
-      waitsFor ->
-        editorView.rootElement.querySelectorAll('.git-line-added').length is 1
-      runs ->
-        expect(editorView.rootElement.querySelectorAll('.git-line-added').length).toBe 1
-        expect(editorView.rootElement.querySelector('.git-line-added')).toHaveData("buffer-row", 1)
+      expect(editorView.rootElement.querySelectorAll('.git-line-added').length).toBe 1
+      expect(editorView.rootElement.querySelector('.git-line-added')).toHaveData("buffer-row", 1)
 
   describe "when the editor has removed lines", ->
     it "highlights the line preceeding the deleted lines", ->
@@ -57,32 +51,23 @@ describe "GitDiff package", ->
       editor.setCursorBufferPosition([5])
       editor.deleteLine()
       advanceClock(editor.getBuffer().stoppedChangingDelay)
-      waitsFor ->
-        editorView.rootElement.querySelectorAll('.git-line-removed').length is 1
-      runs ->
-        expect(editorView.rootElement.querySelectorAll('.git-line-removed').length).toBe 1
-        expect(editorView.rootElement.querySelector('.git-line-removed')).toHaveData("buffer-row", 4)
+      expect(editorView.rootElement.querySelectorAll('.git-line-removed').length).toBe 1
+      expect(editorView.rootElement.querySelector('.git-line-removed')).toHaveData("buffer-row", 4)
 
   describe "when a modified line is restored to the HEAD version contents", ->
     it "removes the diff highlight", ->
       expect(editorView.rootElement.querySelectorAll('.git-line-modified').length).toBe 0
       editor.insertText('a')
       advanceClock(editor.getBuffer().stoppedChangingDelay)
-      waitsFor ->
-        editorView.rootElement.querySelectorAll('.git-line-modified').length is 1
-      runs ->
-        expect(editorView.rootElement.querySelectorAll('.git-line-modified').length).toBe 1
-        editor.backspace()
-        advanceClock(editor.getBuffer().stoppedChangingDelay)
-
-      waitsFor ->
-        editorView.rootElement.querySelectorAll('.git-line-modified').length is 0
-      runs ->
-        expect(editorView.rootElement.querySelectorAll('.git-line-modified').length).toBe 0
+      expect(editorView.rootElement.querySelectorAll('.git-line-modified').length).toBe 1
+      editor.backspace()
+      advanceClock(editor.getBuffer().stoppedChangingDelay)
+      expect(editorView.rootElement.querySelectorAll('.git-line-modified').length).toBe 0
 
   describe "when a modified file is opened", ->
     it "highlights the changed lines", ->
       fs.writeFileSync(path.join(projectPath, 'sample.txt'), "Some different text.")
+      nextTick = false
 
       waitsForPromise ->
         atom.workspace.open(path.join(projectPath, 'sample.txt'))
@@ -90,8 +75,12 @@ describe "GitDiff package", ->
       runs ->
         editorView = atom.views.getView(atom.workspace.getActiveTextEditor())
 
+      setImmediate ->
+        nextTick = true
+
       waitsFor ->
-        editorView.rootElement.querySelectorAll('.git-line-modified').length is 1
+        nextTick
+
       runs ->
         expect(editorView.rootElement.querySelectorAll('.git-line-modified').length).toBe 1
         expect(editorView.rootElement.querySelector('.git-line-modified')).toHaveData("buffer-row", 0)
@@ -108,33 +97,29 @@ describe "GitDiff package", ->
       editor.setCursorBufferPosition([5])
       editor.deleteLine()
       advanceClock(editor.getBuffer().stoppedChangingDelay)
-      waitsFor ->
-        editorView.rootElement.querySelectorAll('.git-line-modified').length > 0
-      runs ->
-        editor.setCursorBufferPosition([0])
-        atom.commands.dispatch(editorView, 'git-diff:move-to-next-diff')
-        expect(editor.getCursorBufferPosition()).toEqual [4, 4]
 
-        atom.commands.dispatch(editorView, 'git-diff:move-to-previous-diff')
-        expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+      editor.setCursorBufferPosition([0])
+      atom.commands.dispatch(editorView, 'git-diff:move-to-next-diff')
+      expect(editor.getCursorBufferPosition()).toEqual [4, 4]
+
+      atom.commands.dispatch(editorView, 'git-diff:move-to-previous-diff')
+      expect(editor.getCursorBufferPosition()).toEqual [0, 0]
 
     it "wraps around to the first/last diff in the file", ->
       editor.insertText('a')
       editor.setCursorBufferPosition([5])
       editor.deleteLine()
       advanceClock(editor.getBuffer().stoppedChangingDelay)
-      waitsFor ->
-        editorView.rootElement.querySelectorAll('.git-line-modified').length > 0
-      runs ->
-        editor.setCursorBufferPosition([0])
-        atom.commands.dispatch(editorView, 'git-diff:move-to-next-diff')
-        expect(editor.getCursorBufferPosition()).toEqual [4, 4]
 
-        atom.commands.dispatch(editorView, 'git-diff:move-to-next-diff')
-        expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+      editor.setCursorBufferPosition([0])
+      atom.commands.dispatch(editorView, 'git-diff:move-to-next-diff')
+      expect(editor.getCursorBufferPosition()).toEqual [4, 4]
 
-        atom.commands.dispatch(editorView, 'git-diff:move-to-previous-diff')
-        expect(editor.getCursorBufferPosition()).toEqual [4, 4]
+      atom.commands.dispatch(editorView, 'git-diff:move-to-next-diff')
+      expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+
+      atom.commands.dispatch(editorView, 'git-diff:move-to-previous-diff')
+      expect(editor.getCursorBufferPosition()).toEqual [4, 4]
 
   describe "when the showIconsInEditorGutter config option is true", ->
     beforeEach ->


### PR DESCRIPTION
We're seeing crashes on Atom stable, and we are pretty sure they are caused by nodegit. We're going to temporarily remove all usage of the `GitRepositoryAsync` while we investigate these crashes.