### PR TITLE
Stop using shadow DOM selectors

### DIFF
--- a/styles/git-diff.less
+++ b/styles/git-diff.less
@@ -2,8 +2,7 @@
 @import "octicon-utf-codes";
 @import "octicon-mixins";
 
-atom-text-editor,
-atom-text-editor::shadow {
+atom-text-editor {
   .gutter .line-number {
     &.git-line-modified {
       border-left: 2px solid @syntax-color-modified;


### PR DESCRIPTION
We are in the process of removing the shadow DOM boundary from `atom-text-editor` elements. This pull request upgrades existing selectors so that they:

* Stop using `:host`.
* Stop using `atom-text-editor::shadow`.
* Prepend syntax class names with `syntax--`.

/cc: @simurai