### PR TITLE
Update diff view to show output similar to "git diff" command

### DIFF
--- a/lib/diff-list-view.coffee
+++ b/lib/diff-list-view.coffee
@@ -1,5 +1,5 @@
 {$$, SelectListView} = require 'atom-space-pen-views'
-{repositoryForPath} = require './helpers'
+{repositoryForPath, getRichDiffsForPath, equalDiffs} = require './helpers'
 
 module.exports =
 class DiffListView extends SelectListView
@@ -22,17 +22,35 @@ class DiffListView extends SelectListView
     @panel.show()
     @focusFilterEditor()
 
-  viewForItem: ({oldStart, newStart, oldLines, newLines, lineText}) ->
+  # add some random comment
+  viewForItem: ({oldStart, newStart, oldLines, newLines, lineText, exceedsLimit, richLines}) ->
     $$ ->
       @li class: 'two-lines', =>
-        @div lineText, class: 'primary-line'
+        @div class: 'primary-line', =>
+          for richDiff in richLines
+            if richDiff.newLineNumber == -1
+              # removed line, add '-' and mark as deleted
+              @code "- #{richDiff.line}", class: 'diff-line removed'
+            else if richDiff.oldLineNumber == -1
+              # added line, prepend '+' and mark as new
+              @code "+ #{richDiff.line}", class: 'diff-line added'
+          if exceedsLimit
+            @div "... more lines", class: 'diff-line more-lines'
         @div "-#{oldStart},#{oldLines} +#{newStart},#{newLines}", class: 'secondary-line'
 
   populate: ->
-    diffs = repositoryForPath(@editor.getPath())?.getLineDiffs(@editor.getPath(), @editor.getText()) ? []
+    repo = repositoryForPath(@editor.getPath())
+    diffs = repo?.getLineDiffs(@editor.getPath(), @editor.getText()) ? []
+    richDiffs = getRichDiffsForPath(repo, @editor.getPath(), @editor.getText()) ? []
+    limit = 12 # limit displayed lines per diff, will show message with "... more lines"
     for diff in diffs
-      bufferRow = if diff.newStart > 0 then diff.newStart - 1 else diff.newStart
-      diff.lineText = @editor.lineTextForBufferRow(bufferRow)?.trim() ? ''
+      diff.richLines = [] # corresponding lines for this range diff
+      diff.exceedsLimit = false # whether or not all lines are included
+      for richDiff in richDiffs
+        if not diff.exceedsLimit and equalDiffs(diff, richDiff)
+          diff.richLines.push richDiff
+          if diff.richLines.length >= limit
+            diff.exceedsLimit = true
     @setItems(diffs)
 
   toggle: ->

--- a/lib/diff-list-view.coffee
+++ b/lib/diff-list-view.coffee
@@ -22,7 +22,6 @@ class DiffListView extends SelectListView
     @panel.show()
     @focusFilterEditor()
 
-  # add some random comment
   viewForItem: ({oldStart, newStart, oldLines, newLines, lineText, exceedsLimit, richLines}) ->
     $$ ->
       @li class: 'two-lines', =>

--- a/lib/diff-list-view.coffee
+++ b/lib/diff-list-view.coffee
@@ -28,7 +28,7 @@ class DiffListView extends SelectListView
         @div class: 'primary-line', =>
           for richDiff in richLines
             if richDiff.newLineNumber is -1
-              # removed line, add '-' and mark as deleted
+              # removed line, prepend '-' and mark as deleted
               @code "- #{richDiff.line}", class: 'diff-line removed'
             else if richDiff.oldLineNumber is -1
               # added line, prepend '+' and mark as new
@@ -45,11 +45,15 @@ class DiffListView extends SelectListView
     for diff in diffs
       diff.richLines = [] # corresponding lines for this range diff
       diff.exceedsLimit = false # whether or not all lines are included
-      for richDiff in richDiffs
-        if not diff.exceedsLimit and equalDiffs(diff, richDiff)
-          diff.richLines.push richDiff
-          if diff.richLines.length >= limit
-            diff.exceedsLimit = true
+    i = j = 0
+    while i < diffs.length and j < richDiffs.length
+      if equalDiffs(diffs[i], richDiffs[j])
+        if not diffs[i].exceedsLimit
+          diffs[i].richLines.push richDiffs[j]
+          diffs[i].exceedsLimit = diffs[i].richLines.length >= limit
+        j += 1
+      else
+        i += 1 # current rich diff belongs to the next diff
     @setItems(diffs)
 
   toggle: ->

--- a/lib/diff-list-view.coffee
+++ b/lib/diff-list-view.coffee
@@ -27,10 +27,10 @@ class DiffListView extends SelectListView
       @li class: 'two-lines', =>
         @div class: 'primary-line', =>
           for richDiff in richLines
-            if richDiff.newLineNumber == -1
+            if richDiff.newLineNumber is -1
               # removed line, add '-' and mark as deleted
               @code "- #{richDiff.line}", class: 'diff-line removed'
-            else if richDiff.oldLineNumber == -1
+            else if richDiff.oldLineNumber is -1
               # added line, prepend '+' and mark as new
               @code "+ #{richDiff.line}", class: 'diff-line added'
           if exceedsLimit

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -15,5 +15,5 @@ module.exports =
   equalDiffs: (diff1, diff2) ->
     if not diff1 or not diff2
       return false
-    diff1.newLines == diff2.newLines and diff1.newStart == diff2.newStart and
-      diff1.oldLines == diff2.oldLines and diff1.oldStart == diff2.oldStart
+    diff1.newLines is diff2.newLines and diff1.newStart is diff2.newStart and
+      diff1.oldLines is diff2.oldLines and diff1.oldStart is diff2.oldStart

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -4,3 +4,16 @@ module.exports =
       if goalPath is directory.getPath() or directory.contains(goalPath)
         return atom.project.getRepositories()[i]
     null
+
+  # Return set of added/removed lines per diff, currently this is not atom repo functionality
+  # so we have to use Repository from 'git-utils'
+  getRichDiffsForPath: (repo, goalPath, text) ->
+    gitRepo = repo?.getRepo()
+    gitRepo?.getLineDiffDetails(gitRepo?.relativize(goalPath), text)
+
+  # Whether or not 2 diffs are equal, e.g. belong to the same group
+  equalDiffs: (diff1, diff2) ->
+    if not diff1 or not diff2
+      return false
+    diff1.newLines == diff2.newLines and diff1.newStart == diff2.newStart and
+      diff1.oldLines == diff2.oldLines and diff1.oldStart == diff2.oldStart

--- a/spec/diff-list-view-spec.coffee
+++ b/spec/diff-list-view-spec.coffee
@@ -24,13 +24,16 @@ describe "git-diff:toggle-diff-list", ->
       editor = atom.workspace.getActiveTextEditor()
       editor.setCursorBufferPosition([4, 29])
       editor.insertText('a')
+      editor.setCursorBufferPosition([7, 5])
+      editor.insertText('\n# comment')
       atom.commands.dispatch(atom.views.getView(editor), 'git-diff:toggle-diff-list')
 
   afterEach ->
     diffListView.cancel()
 
   it "shows a list of all diff hunks", ->
-    expected = "-     while(items.length > 0) {\n+     while(items.length > 0) {a\n-5,1 +5,1"
+    expected = "-     while(items.length > 0) {\n+     while(items.length > 0) {a\n-5,1 +5,1" +
+      "+ # comment\n-8,0 +9,1"
     diffListView = $(atom.views.getView(atom.workspace)).find('.diff-list-view').view()
     expect(diffListView.list.children().text()).toBe expected
 

--- a/spec/diff-list-view-spec.coffee
+++ b/spec/diff-list-view-spec.coffee
@@ -30,8 +30,9 @@ describe "git-diff:toggle-diff-list", ->
     diffListView.cancel()
 
   it "shows a list of all diff hunks", ->
+    expected = "-     while(items.length > 0) {\n+     while(items.length > 0) {a\n-5,1 +5,1"
     diffListView = $(atom.views.getView(atom.workspace)).find('.diff-list-view').view()
-    expect(diffListView.list.children().text()).toBe "while(items.length > 0) {a-5,1 +5,1"
+    expect(diffListView.list.children().text()).toBe expected
 
   it "moves the cursor to the selected hunk", ->
     editor.setCursorBufferPosition([0, 0])

--- a/styles/git-diff.less
+++ b/styles/git-diff.less
@@ -71,6 +71,8 @@ atom-text-editor::shadow {
 }
 
 .diff-line {
+  line-height: .4em;
+  padding: 0em;
   background-color: transparent;
   white-space: pre;
   text-overflow: ellipsis;

--- a/styles/git-diff.less
+++ b/styles/git-diff.less
@@ -71,8 +71,6 @@ atom-text-editor::shadow {
 }
 
 .diff-line {
-  line-height: .4em;
-  padding: 0em;
   background-color: transparent;
   white-space: pre;
   text-overflow: ellipsis;

--- a/styles/git-diff.less
+++ b/styles/git-diff.less
@@ -69,3 +69,17 @@ atom-text-editor::shadow {
     }
   }
 }
+
+.diff-line {
+  background-color: transparent;
+  white-space: pre;
+  text-overflow: ellipsis;
+
+  &.added {
+    color: @syntax-color-added;
+  }
+
+  &.removed {
+    color: @syntax-color-removed;
+  }
+}


### PR DESCRIPTION
This PR updates current output of git-diff-list. Now displayed changes are closer to `git diff` command showing added/removed lines. Note that it will only display changes without intermediate code lines and also up to a limit of 12 lines (currently hard-coded).

Looks like this:
![screen-1](https://cloud.githubusercontent.com/assets/7788766/19213250/ebb8d502-8dc2-11e6-95c3-e7a4354bafa5.png)
