### PR TITLE
Enable usecases where the git repo is not at top level of project

### DIFF
--- a/lib/diff-list-view.coffee
+++ b/lib/diff-list-view.coffee
@@ -29,11 +29,14 @@ class DiffListView extends SelectListView
         @div "-#{oldStart},#{oldLines} +#{newStart},#{newLines}", class: 'secondary-line'
 
   populate: ->
-    diffs = repositoryForPath(@editor.getPath())?.getLineDiffs(@editor.getPath(), @editor.getText()) ? []
-    for diff in diffs
-      bufferRow = if diff.newStart > 0 then diff.newStart - 1 else diff.newStart
-      diff.lineText = @editor.lineTextForBufferRow(bufferRow)?.trim() ? ''
-    @setItems(diffs)
+    repoPromise = repositoryForPath(@editor.getPath())
+    repoPromise.then (repos) =>
+      diffs = repos?.getLineDiffs(@editor.getPath(), @editor.getText()) ? []
+
+      for diff in diffs
+        bufferRow = if diff.newStart > 0 then diff.newStart - 1 else diff.newStart
+        diff.lineText = @editor.lineTextForBufferRow(bufferRow)?.trim() ? ''
+      @setItems(diffs)
 
   toggle: ->
     if @panel.isVisible()

--- a/lib/git-diff-view.coffee
+++ b/lib/git-diff-view.coffee
@@ -83,6 +83,7 @@ class GitDiffView
       @editor.moveToFirstCharacterOfLine()
 
   subscribeToRepository: =>
+    @repository = null
     repoPromise = repositoryForPath(@editor.getPath())
     repoPromise.then (val) =>
       if val?

--- a/lib/git-diff-view.coffee
+++ b/lib/git-diff-view.coffee
@@ -85,11 +85,12 @@ class GitDiffView
   subscribeToRepository: =>
     repoPromise = repositoryForPath(@editor.getPath())
     repoPromise.then (val) =>
-      @repository = val
-      @subscriptions.add @repository.onDidChangeStatuses =>
-        @scheduleUpdate()
-      @subscriptions.add @repository.onDidChangeStatus (changedPath) =>
-        @scheduleUpdate() if changedPath is @editor.getPath()
+      if val?
+        @repository = val
+        @subscriptions.add @repository.onDidChangeStatuses =>
+          @scheduleUpdate()
+        @subscriptions.add @repository.onDidChangeStatus (changedPath) =>
+          @scheduleUpdate() if changedPath is @editor.getPath()
 
   cancelUpdate: ->
     clearImmediate(@immediateId)

--- a/lib/git-diff-view.coffee
+++ b/lib/git-diff-view.coffee
@@ -82,8 +82,10 @@ class GitDiffView
       @editor.setCursorBufferPosition([lineNumber, 0])
       @editor.moveToFirstCharacterOfLine()
 
-  subscribeToRepository: ->
-    if @repository = repositoryForPath(@editor.getPath())
+  subscribeToRepository: =>
+    repoPromise = repositoryForPath(@editor.getPath())
+    repoPromise.then (val) =>
+      @repository = val
       @subscriptions.add @repository.onDidChangeStatuses =>
         @scheduleUpdate()
       @subscriptions.add @repository.onDidChangeStatus (changedPath) =>

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -1,6 +1,6 @@
+{Directory} = require 'atom'
+
 module.exports =
   repositoryForPath: (goalPath) ->
-    for directory, i in atom.project.getDirectories()
-      if goalPath is directory.getPath() or directory.contains(goalPath)
-        return atom.project.getRepositories()[i]
-    null
+    goalDir = new Directory(goalPath)
+    atom.project.repositoryForDirectory(goalDir)

--- a/spec/diff-list-view-spec.coffee
+++ b/spec/diff-list-view-spec.coffee
@@ -30,11 +30,15 @@ describe "git-diff:toggle-diff-list", ->
     diffListView.cancel()
 
   it "shows a list of all diff hunks", ->
-    diffListView = $(atom.views.getView(atom.workspace)).find('.diff-list-view').view()
-    expect(diffListView.list.children().text()).toBe "while(items.length > 0) {a-5,1 +5,1"
+    waits 200
+    runs ->
+      diffListView = $(atom.views.getView(atom.workspace)).find('.diff-list-view').view()
+      expect(diffListView.list.children().text()).toBe "while(items.length > 0) {a-5,1 +5,1"
 
   it "moves the cursor to the selected hunk", ->
-    editor.setCursorBufferPosition([0, 0])
-    diffListView = $(atom.views.getView(atom.workspace)).find('.diff-list-view').view()
-    atom.commands.dispatch(diffListView.element, 'core:confirm')
-    expect(editor.getCursorBufferPosition()).toEqual [4, 4]
+    waits 200
+    runs ->
+      editor.setCursorBufferPosition([0, 0])
+      diffListView = $(atom.views.getView(atom.workspace)).find('.diff-list-view').view()
+      atom.commands.dispatch(diffListView.element, 'core:confirm')
+      expect(editor.getCursorBufferPosition()).toEqual [4, 4]

--- a/spec/git-diff-spec.coffee
+++ b/spec/git-diff-spec.coffee
@@ -81,6 +81,8 @@ describe "GitDiff package", ->
       waitsFor ->
         nextTick
 
+      waits 200
+
       runs ->
         expect(editorView.rootElement.querySelectorAll('.git-line-modified').length).toBe 1
         expect(editorView.rootElement.querySelector('.git-line-modified')).toHaveData("buffer-row", 0)


### PR DESCRIPTION
use atom API `repositoryForDirectory` to get git repo associated
with any open file. Replaces the old behaviour where it is assumed
that the git repo is at top level of the project.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

git-diff uses helper function `repositoryForPath` to get back a gitRepository object for each editor view.

The old implementation of `repositoryForPath` uses the `getRepositories()` API. Which only gives you repositories associated with project's directories. This means the git repo must exist in the projects's top level in order for it to be recognised.

However, there are situations where the git repo associated with a file under edit may not reside in the project's top level. For situations like the following:
```
toplevel/
├── repo_a/
│   ├── .git/
│   ├── file_under_version_control.c
├── repo_b/
│   ├── .git/
```
If you opened `file_under_version_control.c`, git-diff does not work.

The new implementation uses the new atom API [repositoryForDirectory](https://atom.io/docs/api/v1.12.9/Project#instance-repositoryForDirectory). The new API returns a promise and fulfils it asynchronously. Which means the caller of `repositoryForPath` need to be modified as well.

### Alternate Designs

NA

### Benefits

Enable usecases where the git repo is not at top level of project. Allow git-dff to be useful in more usecases. New API uses asynchronous API which allow UI to be more responsive. As `getRepositories()` is being deprecated in atom 2, this change allow the transition to happen.

### Possible Drawbacks

NA

### Applicable Issues

NA
