### PR TITLE
Stop using deprecated `rootElement` property

### DIFF
--- a/lib/git-diff-view.coffee
+++ b/lib/git-diff-view.coffee
@@ -57,7 +57,7 @@ class GitDiffView
     @moveToLineNumber(nextDiffLineNumber)
 
   updateIconDecoration: ->
-    gutter = atom.views.getView(@editor).rootElement?.querySelector('.gutter')
+    gutter = atom.views.getView(@editor).querySelector('.gutter')
     if atom.config.get('editor.showLineNumbers') and atom.config.get('git-diff.showIconsInEditorGutter')
       gutter?.classList.add('git-diff-icon')
     else

--- a/spec/diff-list-view-spec.coffee
+++ b/spec/diff-list-view-spec.coffee
@@ -31,7 +31,7 @@ describe "git-diff:toggle-diff-list", ->
       diffListView?.querySelectorAll('li').length > 0
 
   it "shows a list of all diff hunks", ->
-    diffListView = document.querySelector('.diff-list-view')
+    diffListView = document.querySelector('.diff-list-view ol')
     expect(diffListView.textContent).toBe "while(items.length > 0) {a-5,1 +5,1"
 
   it "moves the cursor to the selected hunk", ->

--- a/spec/git-diff-spec.coffee
+++ b/spec/git-diff-spec.coffee
@@ -29,40 +29,40 @@ describe "GitDiff package", ->
 
   describe "when the editor has modified lines", ->
     it "highlights the modified lines", ->
-      expect(editorView.rootElement.querySelectorAll('.git-line-modified').length).toBe 0
+      expect(editorView.querySelectorAll('.git-line-modified').length).toBe 0
       editor.insertText('a')
       advanceClock(editor.getBuffer().stoppedChangingDelay)
-      expect(editorView.rootElement.querySelectorAll('.git-line-modified').length).toBe 1
-      expect(editorView.rootElement.querySelector('.git-line-modified')).toHaveData("buffer-row", 0)
+      expect(editorView.querySelectorAll('.git-line-modified').length).toBe 1
+      expect(editorView.querySelector('.git-line-modified')).toHaveData("buffer-row", 0)
 
   describe "when the editor has added lines", ->
     it "highlights the added lines", ->
-      expect(editorView.rootElement.querySelectorAll('.git-line-added').length).toBe 0
+      expect(editorView.querySelectorAll('.git-line-added').length).toBe 0
       editor.moveToEndOfLine()
       editor.insertNewline()
       editor.insertText('a')
       advanceClock(editor.getBuffer().stoppedChangingDelay)
-      expect(editorView.rootElement.querySelectorAll('.git-line-added').length).toBe 1
-      expect(editorView.rootElement.querySelector('.git-line-added')).toHaveData("buffer-row", 1)
+      expect(editorView.querySelectorAll('.git-line-added').length).toBe 1
+      expect(editorView.querySelector('.git-line-added')).toHaveData("buffer-row", 1)
 
   describe "when the editor has removed lines", ->
     it "highlights the line preceeding the deleted lines", ->
-      expect(editorView.rootElement.querySelectorAll('.git-line-added').length).toBe 0
+      expect(editorView.querySelectorAll('.git-line-added').length).toBe 0
       editor.setCursorBufferPosition([5])
       editor.deleteLine()
       advanceClock(editor.getBuffer().stoppedChangingDelay)
-      expect(editorView.rootElement.querySelectorAll('.git-line-removed').length).toBe 1
-      expect(editorView.rootElement.querySelector('.git-line-removed')).toHaveData("buffer-row", 4)
+      expect(editorView.querySelectorAll('.git-line-removed').length).toBe 1
+      expect(editorView.querySelector('.git-line-removed')).toHaveData("buffer-row", 4)
 
   describe "when a modified line is restored to the HEAD version contents", ->
     it "removes the diff highlight", ->
-      expect(editorView.rootElement.querySelectorAll('.git-line-modified').length).toBe 0
+      expect(editorView.querySelectorAll('.git-line-modified').length).toBe 0
       editor.insertText('a')
       advanceClock(editor.getBuffer().stoppedChangingDelay)
-      expect(editorView.rootElement.querySelectorAll('.git-line-modified').length).toBe 1
+      expect(editorView.querySelectorAll('.git-line-modified').length).toBe 1
       editor.backspace()
       advanceClock(editor.getBuffer().stoppedChangingDelay)
-      expect(editorView.rootElement.querySelectorAll('.git-line-modified').length).toBe 0
+      expect(editorView.querySelectorAll('.git-line-modified').length).toBe 0
 
   describe "when a modified file is opened", ->
     it "highlights the changed lines", ->
@@ -82,8 +82,8 @@ describe "GitDiff package", ->
         nextTick
 
       runs ->
-        expect(editorView.rootElement.querySelectorAll('.git-line-modified').length).toBe 1
-        expect(editorView.rootElement.querySelector('.git-line-modified')).toHaveData("buffer-row", 0)
+        expect(editorView.querySelectorAll('.git-line-modified').length).toBe 1
+        expect(editorView.querySelector('.git-line-modified')).toHaveData("buffer-row", 0)
 
   describe "when the project paths change", ->
     it "doesn't try to use the destroyed git repository", ->
@@ -126,15 +126,15 @@ describe "GitDiff package", ->
       atom.config.set 'git-diff.showIconsInEditorGutter', true
 
     it "the gutter has a git-diff-icon class", ->
-      expect(editorView.rootElement.querySelector('.gutter')).toHaveClass 'git-diff-icon'
+      expect(editorView.querySelector('.gutter')).toHaveClass 'git-diff-icon'
 
     it "keeps the git-diff-icon class when editor.showLineNumbers is toggled", ->
       atom.config.set 'editor.showLineNumbers', false
-      expect(editorView.rootElement.querySelector('.gutter')).not.toHaveClass 'git-diff-icon'
+      expect(editorView.querySelector('.gutter')).not.toHaveClass 'git-diff-icon'
 
       atom.config.set 'editor.showLineNumbers', true
-      expect(editorView.rootElement.querySelector('.gutter')).toHaveClass 'git-diff-icon'
+      expect(editorView.querySelector('.gutter')).toHaveClass 'git-diff-icon'
 
     it "removes the git-diff-icon class when the showIconsInEditorGutter config option set to false", ->
       atom.config.set 'git-diff.showIconsInEditorGutter', false
-      expect(editorView.rootElement.querySelector('.gutter')).not.toHaveClass 'git-diff-icon'
+      expect(editorView.querySelector('.gutter')).not.toHaveClass 'git-diff-icon'


### PR DESCRIPTION
Now that support for shadow DOM boundaries has been removed, there is no need to use this property anymore. This will also fix the failing tests we are observing on https://github.com/atom/atom/pull/13880.