### PR TITLE
Don't watch editors more than once if they're re-added to the workspace

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -5,11 +5,18 @@ diffListView = null
 
 module.exports =
   activate: ->
+    watchedEditors = new WeakSet()
+
     atom.workspace.observeTextEditors (editor) ->
+      return if watchedEditors.has(editor)
+
       new GitDiffView(editor)
       atom.commands.add atom.views.getView(editor), 'git-diff:toggle-diff-list', ->
         diffListView ?= new DiffListView()
         diffListView.toggle()
+
+      watchedEditors.add(editor)
+      editor.onDidDestroy -> watchedEditors.delete(editor)
 
   deactivate: ->
     diffListView?.destroy()


### PR DESCRIPTION
This will prevent this package from providing its functionality to editors more than once in case they get added to the workspace, then removed from it and finally added back.

/cc: @nathansobo @jasonrudolph