### PR TITLE
Add config option wrapAroundOnMoveToDiff

### DIFF
--- a/lib/git-diff-view.coffee
+++ b/lib/git-diff-view.coffee
@@ -52,7 +52,8 @@ class GitDiffView
       firstDiffLineNumber = Math.min(newStart - 1, firstDiffLineNumber)
 
     # Wrap around to the first diff in the file
-    nextDiffLineNumber = firstDiffLineNumber unless nextDiffLineNumber?
+    if atom.config.get('git-diff.wrapAroundOnMoveToDiff') and not nextDiffLineNumber?
+      nextDiffLineNumber = firstDiffLineNumber
 
     @moveToLineNumber(nextDiffLineNumber)
 
@@ -73,7 +74,8 @@ class GitDiffView
       lastDiffLineNumber = Math.max(newStart - 1, lastDiffLineNumber)
 
     # Wrap around to the last diff in the file
-    previousDiffLineNumber = lastDiffLineNumber if previousDiffLineNumber is -1
+    if atom.config.get('git-diff.wrapAroundOnMoveToDiff') and previousDiffLineNumber is -1
+      previousDiffLineNumber = lastDiffLineNumber
 
     @moveToLineNumber(previousDiffLineNumber)
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
       "type": "boolean",
       "default": false,
       "description": "Show colored icons for added (`+`), modified (`·`) and removed (`-`) lines in the editor's gutter, instead of colored markers (`|`)."
+    },
+    "wrapAroundOnMoveToDiff": {
+      "type": "boolean",
+      "default": true,
+      "description": "Wraps around to the first/last diff in the file when moving to next/previous diff."
     }
   }
 }

--- a/spec/git-diff-spec.coffee
+++ b/spec/git-diff-spec.coffee
@@ -121,6 +121,29 @@ describe "GitDiff package", ->
       atom.commands.dispatch(editorView, 'git-diff:move-to-previous-diff')
       expect(editor.getCursorBufferPosition()).toEqual [4, 4]
 
+    describe "when the wrapAroundOnMoveToDiff config option is false", ->
+      beforeEach ->
+        atom.config.set 'git-diff.wrapAroundOnMoveToDiff', false
+
+      it "does not wraps around to the first/last diff in the file", ->
+        editor.insertText('a')
+        editor.setCursorBufferPosition([5])
+        editor.deleteLine()
+        advanceClock(editor.getBuffer().stoppedChangingDelay)
+
+        editor.setCursorBufferPosition([0])
+        atom.commands.dispatch(editorView, 'git-diff:move-to-next-diff')
+        expect(editor.getCursorBufferPosition()).toEqual [4, 4]
+
+        atom.commands.dispatch(editorView, 'git-diff:move-to-next-diff')
+        expect(editor.getCursorBufferPosition()).toEqual [4, 4]
+
+        atom.commands.dispatch(editorView, 'git-diff:move-to-previous-diff')
+        expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+
+        atom.commands.dispatch(editorView, 'git-diff:move-to-previous-diff')
+        expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+
   describe "when the showIconsInEditorGutter config option is true", ->
     beforeEach ->
       atom.config.set 'git-diff.showIconsInEditorGutter', true


### PR DESCRIPTION

### Description of the Change

Add new config option `wrapAroundOnMoveToDiff`(default `true`).

Default value is compatible with existing behavior.
When set to `false`, it doesn't wrap around to first/last diff on move-to-next/previous-diff

### Alternate Designs

None

### Benefits

I use `git-diff:move-to-next-diff` and `git-diff:move-to-previous-diff` mainly to review changes before pushing remote.

My typical usecase is

1. Move cursor at first line of buffer.
2. Execute `git-diff:move-to-next-diff` and review change, then repeat `move-to-next` and review till last diff in buffer.

In this scenario, current move wrap around behavior is not desirable.
If wrap was disabled, I can know that cursor is at last diff by seeing no movement happened by `git-diff:move-to-next-diff` command.

### Possible Drawbacks

None

### Applicable Issues

None
