### PR TITLE
Position decoration at top of line number when the first line is deleted

### DIFF
--- a/lib/git-diff-view.coffee
+++ b/lib/git-diff-view.coffee
@@ -111,7 +111,10 @@ class GitDiffView
       if oldLines is 0 and newLines > 0
         @markRange(startRow, endRow, 'git-line-added')
       else if newLines is 0 and oldLines > 0
-        @markRange(startRow, startRow, 'git-line-removed')
+        if startRow < 0
+          @markRange(0, 0, 'git-previous-line-removed')
+        else
+          @markRange(startRow, startRow, 'git-line-removed')
       else
         @markRange(startRow, endRow, 'git-line-modified')
     return

--- a/spec/git-diff-spec.coffee
+++ b/spec/git-diff-spec.coffee
@@ -54,6 +54,15 @@ describe "GitDiff package", ->
       expect(editorView.querySelectorAll('.git-line-removed').length).toBe 1
       expect(editorView.querySelector('.git-line-removed')).toHaveData("buffer-row", 4)
 
+  describe "when the editor has removed the first line", ->
+    it "highlights the line preceeding the deleted lines", ->
+      expect(editorView.querySelectorAll('.git-line-added').length).toBe 0
+      editor.setCursorBufferPosition([0, 0])
+      editor.deleteLine()
+      advanceClock(editor.getBuffer().stoppedChangingDelay)
+      expect(editorView.querySelectorAll('.git-previous-line-removed').length).toBe 1
+      expect(editorView.querySelector('.git-previous-line-removed')).toHaveData("buffer-row", 0)
+
   describe "when a modified line is restored to the HEAD version contents", ->
     it "removes the diff highlight", ->
       expect(editorView.querySelectorAll('.git-line-modified').length).toBe 0

--- a/styles/git-diff.less
+++ b/styles/git-diff.less
@@ -29,6 +29,22 @@ atom-text-editor {
       margin-top: -@size;
       pointer-events: none;
     }
+
+    &.git-previous-line-removed:before {
+      @size: 4px;
+
+      position: absolute;
+      left: 0;
+      top: 0;
+      height: 0;
+      width: 0;
+      content: " ";
+      border: solid transparent;
+      border-left-color: @syntax-color-removed;
+      border-width: @size;
+      margin-top: -@size;
+      pointer-events: none;
+    }
   }
   .gutter.git-diff-icon .line-number {
     width: 100%;

--- a/styles/git-diff.less
+++ b/styles/git-diff.less
@@ -14,12 +14,11 @@ atom-text-editor {
       padding-left: ~"calc(0.5em - 2px)";
     }
 
-    &.git-line-removed:before {
-      @size: 4px;
-
+    @size: 4px;
+    &.git-line-removed:before,
+    &.git-previous-line-removed:before {
       position: absolute;
       left: 0;
-      bottom: -@size;
       height: 0;
       width: 0;
       content: " ";
@@ -29,23 +28,14 @@ atom-text-editor {
       margin-top: -@size;
       pointer-events: none;
     }
-
+    &.git-line-removed:before {
+      bottom: -@size;
+    }
     &.git-previous-line-removed:before {
-      @size: 4px;
-
-      position: absolute;
-      left: 0;
       top: 0;
-      height: 0;
-      width: 0;
-      content: " ";
-      border: solid transparent;
-      border-left-color: @syntax-color-removed;
-      border-width: @size;
-      margin-top: -@size;
-      pointer-events: none;
     }
   }
+
   .gutter.git-diff-icon .line-number {
     width: 100%;
     border-left: none;

--- a/styles/git-diff.less
+++ b/styles/git-diff.less
@@ -65,12 +65,18 @@ atom-text-editor {
       color: @syntax-color-added;
     }
 
-    &.git-line-removed:before {
+    &.git-line-removed:before,
+    &.git-previous-line-removed:before {
       border: none; // reset triangle
       content: @dash;
       color: @syntax-color-removed;
       position: relative;
+    }
+    &.git-line-removed:before {
       top: .6em;
+    }
+    &.git-previous-line-removed:before {
+      top: -.6em;
     }
   }
 }


### PR DESCRIPTION
### Description of the Change

This PR adds special handling for the first line of a file being deleted. Currently, the `git-line-removed` class always adds decoration to the bottom of the line number. This works well for everything except when the first line is deleted. In that case, we attempt to decorate row `-1`, which gets clipped to `0`. Then the decorations make it look like we've deleted the second line instead of the first. Now if we need to decorate row `-1`, we instead add `git-previous-line-removed` class, which duplicates the existing style except for the positioning of the decoration.

### Benefits

Correctly indicates when the first line has been deleted.

### Alternate Designs

We could have changed the `git-line-removed` styling to always apply to always render the decoration at the top and apply the decoration to the next line instead. That was a bigger change and seems like it could have issues at the end of the file instead.

### Possible Drawbacks

The duplicated style could maybe be done more elegantly with LESS. @simurai I'll defer to you on that on.

### Applicable Issues

Closes #128